### PR TITLE
Fix naming of dependency

### DIFF
--- a/config/install/core.entity_form_display.media.instagram.default.yml
+++ b/config/install/core.entity_form_display.media.instagram.default.yml
@@ -2,7 +2,7 @@ langcode: und
 status: true
 dependencies:
   config:
-    - field.field.media.instgram.instagram
+    - field.field.media.instagram.instagram
     - media_entity.bundle.instagram
 id: media.instagram.default
 targetEntityType: media


### PR DESCRIPTION
A dependency is misspelled, and causes the module to fail installation with the following error:
"Unable to install Media Pinkeye, core.entity_form_display.media.instagram.default has unmet dependencies."
