### PR TITLE
typo in configuration dependencies for entity_media_instagram

### DIFF
--- a/config/install/core.entity_form_display.media.instagram.default.yml
+++ b/config/install/core.entity_form_display.media.instagram.default.yml
@@ -2,7 +2,7 @@ langcode: und
 status: true
 dependencies:
   config:
-    - field.field.media.instgram.instagram
+    - field.field.media.instagram.instagram
     - media_entity.bundle.instagram
 id: media.instagram.default
 targetEntityType: media


### PR DESCRIPTION
we encounter this typo when trying to implement pinkeye in drupal 8 beta9
