### PR TITLE
Fix invalid base table in media view

### DIFF
--- a/config/install/views.view.media.yml
+++ b/config/install/views.view.media.yml
@@ -10,7 +10,7 @@ label: Media
 module: views
 description: 'Find and manage media.'
 tag: ''
-base_table: media
+base_table: media_field_data
 base_field: mid
 core: 8.x
 display:


### PR DESCRIPTION
When installing Media Pinkeye, I could not get the media view to work -- it would throw SQL errors left and right. Upon further investigation, I discovered that https://www.drupal.org/node/2447313 broke it -- Views' row plugin deriver for entities will favor the *_field_data table over the entity base table, which means that the view thought it had no valid row plugin (since the base table of the view must match the base table defined for the row plugin). This corrects the problem.
